### PR TITLE
LWDEV-3989

### DIFF
--- a/src/Lykke.Job.CandlesProducer.Services/Candles/CandlesManager.cs
+++ b/src/Lykke.Job.CandlesProducer.Services/Candles/CandlesManager.cs
@@ -195,18 +195,21 @@ namespace Lykke.Job.CandlesProducer.Services.Candles
                 changedUpdateResults.Add(candleUpdateResult);
             }
 
-            // Updates mid candle
+            // Updates mid candle only while ask candle is updated, to prevent volume doubling in mid candle
 
-            var midPriceCandleUpdateResult = _candlesGenerator.UpdateTradingVolume(
-                assetPair,
-                timestamp,
-                volume,
-                CandlePriceType.Mid,
-                timeInterval);
-
-            if (midPriceCandleUpdateResult.WasChanged)
+            if (isBuy)
             {
-                changedUpdateResults.Add(midPriceCandleUpdateResult);
+                var midPriceCandleUpdateResult = _candlesGenerator.UpdateTradingVolume(
+                    assetPair,
+                    timestamp,
+                    volume,
+                    CandlePriceType.Mid,
+                    timeInterval);
+
+                if (midPriceCandleUpdateResult.WasChanged)
+                {
+                    changedUpdateResults.Add(midPriceCandleUpdateResult);
+                }
             }
         }
     }

--- a/src/Lykke.Job.CandlesProducer.Services/Candles/CandlesPublisher.cs
+++ b/src/Lykke.Job.CandlesProducer.Services/Candles/CandlesPublisher.cs
@@ -8,7 +8,6 @@ using Lykke.Job.CandlesProducer.Core.Domain.Candles;
 using Lykke.Job.CandlesProducer.Core.Services;
 using Lykke.Job.CandlesProducer.Core.Services.Candles;
 using Lykke.Job.CandlesProducer.Services.Candles.LegacyContract;
-using Lykke.Job.CandlesProducer.Services.Settings;
 using Lykke.RabbitMqBroker.Publisher;
 
 namespace Lykke.Job.CandlesProducer.Services.Candles
@@ -17,12 +16,12 @@ namespace Lykke.Job.CandlesProducer.Services.Candles
     public class CandlesPublisher : ICandlesPublisher
     {
         private readonly IRabbitMqPublishersFactory _publishersFactory;
-        private readonly CandlesPublicationRabbitSettings _settings;
+        private readonly IRabbitPublicationSettings _settings;
 
         private RabbitMqPublisher<CandleMessageV1> _legacyPublisher;
         private RabbitMqPublisher<CandlesUpdatedEvent> _publisher;
 
-        public CandlesPublisher(IRabbitMqPublishersFactory publishersFactory, CandlesPublicationRabbitSettings settings)
+        public CandlesPublisher(IRabbitMqPublishersFactory publishersFactory, IRabbitPublicationSettings settings)
         {
             _publishersFactory = publishersFactory;
             _settings = settings;

--- a/src/Lykke.Job.CandlesProducer.Services/HealthService.cs
+++ b/src/Lykke.Job.CandlesProducer.Services/HealthService.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Lykke.Job.CandlesProducer.Core.Domain.Health;
 using Lykke.Job.CandlesProducer.Core.Services;
 

--- a/src/Lykke.Job.CandlesProducer.Services/IRabbitPublicationSettings.cs
+++ b/src/Lykke.Job.CandlesProducer.Services/IRabbitPublicationSettings.cs
@@ -1,0 +1,8 @@
+﻿namespace Lykke.Job.CandlesProducer.Services
+{
+    public interface IRabbitPublicationSettings
+    {
+        string ConnectionString { get; }
+        string Namespace { get; }
+    }
+}

--- a/src/Lykke.Job.CandlesProducer.Services/IRabbitSubscriptionSettings.cs
+++ b/src/Lykke.Job.CandlesProducer.Services/IRabbitSubscriptionSettings.cs
@@ -1,0 +1,8 @@
+﻿namespace Lykke.Job.CandlesProducer.Services
+{
+    public interface IRabbitSubscriptionSettings
+    {
+        string ConnectionString { get; }
+        string EndpointName { get; }
+    }
+}

--- a/src/Lykke.Job.CandlesProducer.Services/Settings/CandlesPublicationRabbitSettings.cs
+++ b/src/Lykke.Job.CandlesProducer.Services/Settings/CandlesPublicationRabbitSettings.cs
@@ -1,8 +1,0 @@
-﻿namespace Lykke.Job.CandlesProducer.Services.Settings
-{
-    public class CandlesPublicationRabbitSettings
-    {
-        public string ConnectionString { get; set; }
-        public string Namespace { get; set; }
-    }
-}

--- a/src/Lykke.Job.CandlesProducer/Settings/AppSettings.cs
+++ b/src/Lykke.Job.CandlesProducer/Settings/AppSettings.cs
@@ -1,8 +1,7 @@
-﻿using Lykke.Job.CandlesProducer.Services.Settings;
-using Lykke.Service.Assets.Client.Custom;
+﻿using Lykke.Service.Assets.Client.Custom;
 using Lykke.SettingsReader.Attributes;
 
-namespace Lykke.Job.CandlesProducer
+namespace Lykke.Job.CandlesProducer.Settings
 {
     public class AppSettings
     {        

--- a/src/Lykke.Job.CandlesProducer/Settings/AssetsCacheSettings.cs
+++ b/src/Lykke.Job.CandlesProducer/Settings/AssetsCacheSettings.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Lykke.Job.CandlesProducer.Services.Settings
+namespace Lykke.Job.CandlesProducer.Settings
 {
     public class AssetsCacheSettings
     {

--- a/src/Lykke.Job.CandlesProducer/Settings/AzureQueueSettings.cs
+++ b/src/Lykke.Job.CandlesProducer/Settings/AzureQueueSettings.cs
@@ -1,4 +1,4 @@
-namespace Lykke.Job.CandlesProducer.Services.Settings
+﻿namespace Lykke.Job.CandlesProducer.Settings
 {
     public class AzureQueueSettings
     {

--- a/src/Lykke.Job.CandlesProducer/Settings/CandlesGeneratorSettings.cs
+++ b/src/Lykke.Job.CandlesProducer/Settings/CandlesGeneratorSettings.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Lykke.Job.CandlesProducer.Services.Settings
+namespace Lykke.Job.CandlesProducer.Settings
 {
     public class CandlesGeneratorSettings
     {

--- a/src/Lykke.Job.CandlesProducer/Settings/CandlesProducerSettings.cs
+++ b/src/Lykke.Job.CandlesProducer/Settings/CandlesProducerSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace Lykke.Job.CandlesProducer.Services.Settings
+﻿namespace Lykke.Job.CandlesProducer.Settings
 {
     public class CandlesProducerSettings
     {

--- a/src/Lykke.Job.CandlesProducer/Settings/CandlesPublicationRabbitSettings.cs
+++ b/src/Lykke.Job.CandlesProducer/Settings/CandlesPublicationRabbitSettings.cs
@@ -1,0 +1,11 @@
+﻿using Lykke.Job.CandlesProducer.Services;
+
+namespace Lykke.Job.CandlesProducer.Settings
+{
+    public class CandlesPublicationRabbitSettings : IRabbitPublicationSettings
+    {
+        public string ConnectionString { get; set; }
+        public string Namespace { get; set; }
+    }
+}
+

--- a/src/Lykke.Job.CandlesProducer/Settings/DbSettings.cs
+++ b/src/Lykke.Job.CandlesProducer/Settings/DbSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace Lykke.Job.CandlesProducer.Services.Settings
+﻿namespace Lykke.Job.CandlesProducer.Settings
 {
     public class DbSettings
     {

--- a/src/Lykke.Job.CandlesProducer/Settings/RabbitSettings.cs
+++ b/src/Lykke.Job.CandlesProducer/Settings/RabbitSettings.cs
@@ -1,9 +1,9 @@
-﻿namespace Lykke.Job.CandlesProducer.Services.Settings
+﻿namespace Lykke.Job.CandlesProducer.Settings
 {
     public class RabbitSettings
     {
         public string QuotesSubscribtion { get; set; }
-        public string TradesSubscription { get; set; }
+        public RabbitSubscriptionSettingsSettings TradesSubscription { get; set; }
         public CandlesPublicationRabbitSettings CandlesPublication { get; set; }
     }
 }

--- a/src/Lykke.Job.CandlesProducer/Settings/RabbitSubscriptionSettings.cs
+++ b/src/Lykke.Job.CandlesProducer/Settings/RabbitSubscriptionSettings.cs
@@ -1,0 +1,13 @@
+﻿
+using Lykke.Job.CandlesProducer.Services;
+using Lykke.SettingsReader.Attributes;
+
+namespace Lykke.Job.CandlesProducer.Settings
+{
+    public class RabbitSubscriptionSettingsSettings : IRabbitSubscriptionSettings
+    {
+        public string ConnectionString { get; set; }
+        [Optional]
+        public string EndpointName { get; set; }
+    }
+}

--- a/src/Lykke.Job.CandlesProducer/Settings/SlackNotificationsSettings.cs
+++ b/src/Lykke.Job.CandlesProducer/Settings/SlackNotificationsSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace Lykke.Job.CandlesProducer.Services.Settings
+﻿namespace Lykke.Job.CandlesProducer.Settings
 {
     public class SlackNotificationsSettings
     {

--- a/src/Lykke.Job.CandlesProducer/Startup.cs
+++ b/src/Lykke.Job.CandlesProducer/Startup.cs
@@ -11,7 +11,7 @@ using Lykke.Job.CandlesProducer.Core.Domain.Candles;
 using Lykke.Job.CandlesProducer.Core.Services;
 using Lykke.Job.CandlesProducer.Models;
 using Lykke.Job.CandlesProducer.Modules;
-using Lykke.Job.CandlesProducer.Services.Settings;
+using Lykke.Job.CandlesProducer.Settings;
 using Lykke.Logs;
 using Lykke.Logs.Slack;
 using Lykke.SettingsReader;

--- a/src/Lykke.Job.CandlesProducer/appsettings.json
+++ b/src/Lykke.Job.CandlesProducer/appsettings.json
@@ -11,7 +11,10 @@
     },
     "Rabbit": {
       "QuotesSubscribtion": "",
-      "TradesSubscription": "",
+      "TradesSubscription": {
+        "ConnectionString": "",
+        "EndpointName": ""
+      },
       "CandlesPublication": {
         "ConnectionString": "",
         "Namespace": ""


### PR DESCRIPTION
- Mid candles volume doubling was fixed
- Direct asset volume is used for candles now
- Spot trade exchange name was moved to the settings